### PR TITLE
chore: Update package-lock.json with scoped package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "q5m",
+  "name": "@q5m/q5m",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "q5m",
+      "name": "@q5m/q5m",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
  Following PR #6, update package-lock.json to reflect the scoped package name
  change from 'q5m' to '@q5m/q5m' for npm public publishing configuration.